### PR TITLE
Updated Info.plist with NSAppTransportSecurity exception for localhost.

### DIFF
--- a/syncthing-bar/Info.plist
+++ b/syncthing-bar/Info.plist
@@ -30,5 +30,16 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>localhost</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Added the changes suggested in https://github.com/m0ppers/syncthing-bar/issues/21 to Info.plist. Menu items now work again on El Capitan.