### PR TITLE
Display folder label in menu bar

### DIFF
--- a/syncthing-bar/SyncthingBar.swift
+++ b/syncthing-bar/SyncthingBar.swift
@@ -106,7 +106,7 @@ public class SyncthingBar: NSObject {
         var folderCount = 0
         for folder in folders {
             let folderItem : NSMenuItem = NSMenuItem()
-            folderItem.title = "Open \(folder.id) in Finder"
+            folderItem.title = "Open \(folder.label.length > 0 ? folder.label : folder.id) in Finder"
             folderItem.representedObject = folder
             folderItem.action = Selector("openFolderAction:")
             folderItem.enabled = true

--- a/syncthing-bar/SyncthingFolder.swift
+++ b/syncthing-bar/SyncthingFolder.swift
@@ -10,10 +10,17 @@ import Foundation
 
 public class SyncthingFolder {
     var id: NSString
+    var label: NSString
     var path: NSString
     
     public init(id: NSString, path: NSString) {
         self.id = id
         self.path = path
+        self.label = ""
+    }
+    
+    public convenience init(id: NSString, path: NSString, label: NSString) {
+        self.init(id: id, path: path)
+        self.label = label
     }
 }

--- a/syncthing-bar/SyncthingRunner.swift
+++ b/syncthing-bar/SyncthingRunner.swift
@@ -159,6 +159,7 @@ class SyncthingRunner: NSObject {
             
             var request: NSMutableURLRequest
             var idElement: NSString
+            let labelElement: NSString = "label"
             var pathElement: NSString
             var foldersElement: NSString
             if version![0] == 0 && version![1] == 10 {
@@ -202,8 +203,14 @@ class SyncthingRunner: NSObject {
                             let id = object[idElement] as? String
                             let pathTemp = object[pathElement] as? String
                             let path = ((pathTemp)! as NSString).stringByExpandingTildeInPath
-                                                        
-                            return SyncthingFolder(id: id!, path: path)
+                            
+                            if (self.version![0] == 0 && self.version![1] == 10) {
+                                // support API version 0.10
+                                return SyncthingFolder(id: id!, path: path)
+                            }
+                            
+                            let label = object[labelElement] as? String
+                            return SyncthingFolder(id: id!, path: path, label: label!)
                         })
                         
                         let folderData = ["folders": folderStructArr]


### PR DESCRIPTION
Since API v0.13.0 distinct folder labels are supported. If a folder
label is set display it instead of a possibly cryptic folder ID.
Fallback to folder ID if no label is set.