### PR TITLE
Added installation with homebrew to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ Syncthingbar is intended for local usage only. It will hardcode host and port an
 ## Installation Package
 
 The latest release can be found on the [releases tab](https://github.com/m0ppers/syncthing-bar/releases)
+
+## Installation using homebrew
+
+After you have installed [homebrew](http://brew.sh) you can install syncthing-bar with the `brew` command:
+
+    brew tap caskroom/cask
+    brew cask install syncthing-bar


### PR DESCRIPTION
Using homebrew is an easy way of installing and updating syncthing-bar.